### PR TITLE
adding .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */nitsm/pinmapinterfaces.py
+    */nitsm/__init__.py


### PR DESCRIPTION
Removing the generated pinmapinterfaces.py file from code coverage as well as empty __init__.py.