### PR TITLE
Increase system test timeout to 3 minutes

### DIFF
--- a/systemtests/conftest.py
+++ b/systemtests/conftest.py
@@ -35,7 +35,7 @@ class SystemTestRunner:
                 "/quit",
             ],
             stdout=subprocess.PIPE,
-            timeout=60,
+            timeout=180,
             check=True,
         )
         return True


### PR DESCRIPTION
Some of the system tests on my VM are running dangerously close to 1 min, sometimes exceeding it. I'd like to increase the timeout to 3 minutes.