### PR TITLE
Require pywin32 and windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
     ],
     python_requires=">=3.6",
-    install_requires=["pywin32>=228;platform_system=='Windows'"]
+    install_requires=["pywin32>=228;platform_system=='Windows'"],
 )


### PR DESCRIPTION
Will require users running `pip install nitsm` to be running windows due to the dependency on pywin32.
pywin32 will be automatically installed if not already present.