### PR TITLE
Upgrade requirements and reinstall nitsm in CI pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,10 @@ jobs:
       pip install --upgrade -r requirements.txt
     displayName: 'Install or upgrade required packages'
 
+  # installing from local automatically builds and re-installs the package without using any cached versions
   - script: |
-      pip uninstall -y nitsm
-    displayName: 'Uninstall previous version of nitsm if present'
-
-  - script: |
-      pip install --no-cache .
-    displayName: 'Install nitsm'
+      pip install .
+    displayName: 'Install/reinstall nitsm'
 
   - script: |
       pytest tests systemtests --junitxml=test-results.xml --cov=nitsm --cov-report=xml


### PR DESCRIPTION
Changes to pipeline:
1. upgrade pip before doing anything else
2. install or upgrade any packages listed in the requirements file
3. reinstall nitsm with version cloned from git

Decisions made here:
1. Will not uninstall any packages other than nitsm since those packages aren't being tested here. The only package that will be reinstalled will be nitsm to guarantee we have the latest version installed before running tests.
2. No virtual environment. We initially explored isolating packages with a virtual environment, however it became clear that using a virtual environment complicates the system tests more than we would like since TestStand has to be configured to use one.