### PR TITLE
Make parameters for get_pin_names optional

### DIFF
--- a/src/nitsm/tsmcontext.py
+++ b/src/nitsm/tsmcontext.py
@@ -109,7 +109,9 @@ class SemiconductorModuleContext:
     # General and Advanced
 
     def get_pin_names(
-        self, instrument_type_id: "_InstrTypeIdArg", capability: "_CapabilityArg"
+        self,
+        instrument_type_id: "_InstrTypeIdArg" = nitsm.enums.InstrumentTypeIdConstants.ANY,
+        capability: "_CapabilityArg" = nitsm.enums.Capability.ALL,
     ) -> _Tuple["_StringTuple", "_StringTuple"]:
         """
         Returns all DUT and system pins available in the Semiconductor Module context that are


### PR DESCRIPTION
LabVIEW marks these parameters as optional and .NET provides multiple overloads with and without these params.

Our early users are expecting the same behavior.  We can achieve the best of both worlds by using optional parameters with default values.