### PR TITLE
Allow code module decorator to be used anywhere

### DIFF
--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -5,16 +5,16 @@ from .enums import Capability, InstrumentTypeIdConstants
 __all__ = ["SemiconductorModuleContext", "Capability", "InstrumentTypeIdConstants"]
 
 
-def code_module(func):
+def code_module(callable_):
     """
     Converts the Semiconductor Module context passed from TestStand into a native Python object. The
     Semiconductor Module context must be the first argument to the function.
     """
 
-    @functools.wraps(func)
-    def decorator(tsm_context, *args, **kwargs):
+    @functools.wraps(callable_)
+    def nitsm_code_module(tsm_context, *args, **kwargs):
         if not isinstance(tsm_context, SemiconductorModuleContext):
             tsm_context = SemiconductorModuleContext(tsm_context)
-        return func(tsm_context, *args, **kwargs)
+        return callable_(tsm_context, *args, **kwargs)
 
-    return decorator
+    return nitsm_code_module


### PR DESCRIPTION
Current implementation only allows functions decorated with `code_module` to be called from TestStand.

This change will also allow code modules to call other code modules.