### PR TITLE
Add pr specification with branch filter to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,11 @@
 trigger:
 - main
 
+pr:
+  branches:
+    include:
+    - main
+
 jobs:
 - job: CI
   workspace:


### PR DESCRIPTION
In preparation for setting up manually triggered PRs, we should explicitly mark which branches trigger a PR build (default is any branch).
Followed the syntax as defined [in Microsoft documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#branches)