### PR TITLE
Allow code_module decorator to be used in classes

### DIFF
--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -34,8 +34,8 @@ class code_module:
         except StopIteration:
             raise TypeError(
                 (
-                    "The number of arguments to the code module is less than expected. It must"
-                    "accept as it's first argument the Semiconductor Module context passed from"
+                    "The number of arguments to the code module is less than expected. It must "
+                    "accept as it's first argument the Semiconductor Module context passed from "
                     "TestStand or another code module.",
                 )
             )

--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -34,9 +34,9 @@ class code_module:
         except StopIteration:
             raise TypeError(
                 (
-                    "The number of arguments to the code module is less expected. It must accept "
-                    "as it's first argument the Semiconductor Module context passed from TestStand "
-                    "or another code module.",
+                    "The number of arguments to the code module is less than expected. It must"
+                    "accept as it's first argument the Semiconductor Module context passed from"
+                    "TestStand or another code module.",
                 )
             )
 

--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -36,5 +36,5 @@ class code_module:
                 raise ValueError(
                     f"Failed to convert Semiconductor Module context from class '{class_name}'."
                 )
-            args = *args[:index], tsm_context, *args[index + 1 :]  # noqa E203
+            args = *args[:index], tsm_context, *args[index + 1 :]  # noqa: E203
         return self._callable(*args, **kwargs)

--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -11,11 +11,11 @@ class code_module:
     def __init__(self, callable_):
         """
         Converts the Semiconductor Module context passed from TestStand into a native Python object.
-        The Semiconductor Module context must be the first positional argument to the function or
-        method.
+        The Semiconductor Module context must be the first argument to the function or method.
         """
 
         self._callable = callable_
+        self._signature = inspect.signature(callable_)
         functools.update_wrapper(self, callable_)
 
     def __get__(self, instance, owner):
@@ -23,18 +23,33 @@ class code_module:
         return self.__class__(callable_)
 
     def __call__(self, *args, **kwargs):
+        bound_arguments = self._signature.bind(*args, **kwargs)
+        arguments_iter = iter(bound_arguments.arguments.items())
+
+        # find potential argument that could be the tsm context
         try:
-            index = int(inspect.isclass(args[0]))  # class method check
-            tsm_context = args[index]
-        except IndexError:
-            raise TypeError("Invalid number of positional arguments.", self._callable)
-        if not isinstance(tsm_context, SemiconductorModuleContext):
-            try:
-                tsm_context = SemiconductorModuleContext(tsm_context)
-            except Exception:
-                class_name = tsm_context.__class__.__name__
-                raise ValueError(
-                    f"Failed to convert Semiconductor Module context from class '{class_name}'."
+            argument = next(arguments_iter)  # get first argument
+            if inspect.isclass(argument[1]):  # class method check
+                argument = next(arguments_iter)  # move to second argument
+        except StopIteration:
+            raise TypeError(
+                (
+                    "The number of arguments to the code module is less expected. It must accept "
+                    "as it's first argument the Semiconductor Module context passed from TestStand "
+                    "or another code module.",
                 )
-            args = *args[:index], tsm_context, *args[index + 1 :]  # noqa: E203
-        return self._callable(*args, **kwargs)
+            )
+
+        # attempt to wrap argument in a SemiconductorModuleContext class
+        argument_name, argument_value = argument
+        if not isinstance(argument_value, SemiconductorModuleContext):
+            try:
+                argument_value = SemiconductorModuleContext(argument_value)
+            except Exception:
+                class_name = argument_value.__class__.__name__
+                raise ValueError(
+                    f"Failed to convert Semiconductor Module context from class '{class_name}'.",
+                )
+            bound_arguments.arguments[argument_name] = argument_value
+
+        return self._callable(*bound_arguments.args, **bound_arguments.kwargs)

--- a/src/nitsm/codemoduleapi.py
+++ b/src/nitsm/codemoduleapi.py
@@ -1,20 +1,40 @@
+import inspect
 import functools
 from .tsmcontext import SemiconductorModuleContext
 from .enums import Capability, InstrumentTypeIdConstants
 
-__all__ = ["SemiconductorModuleContext", "Capability", "InstrumentTypeIdConstants"]
+__all__ = ["SemiconductorModuleContext", "Capability", "InstrumentTypeIdConstants", "code_module"]
 
 
-def code_module(callable_):
-    """
-    Converts the Semiconductor Module context passed from TestStand into a native Python object. The
-    Semiconductor Module context must be the first argument to the function.
-    """
+# noinspection PyPep8Naming
+class code_module:
+    def __init__(self, callable_):
+        """
+        Converts the Semiconductor Module context passed from TestStand into a native Python object.
+        The Semiconductor Module context must be the first positional argument to the function or
+        method.
+        """
 
-    @functools.wraps(callable_)
-    def nitsm_code_module(tsm_context, *args, **kwargs):
+        self._callable = callable_
+        functools.update_wrapper(self, callable_)
+
+    def __get__(self, instance, owner):
+        callable_ = self._callable.__get__(instance, owner)
+        return self.__class__(callable_)
+
+    def __call__(self, *args, **kwargs):
+        try:
+            index = int(inspect.isclass(args[0]))  # class method check
+            tsm_context = args[index]
+        except IndexError:
+            raise TypeError("Invalid number of positional arguments.", self._callable)
         if not isinstance(tsm_context, SemiconductorModuleContext):
-            tsm_context = SemiconductorModuleContext(tsm_context)
-        return callable_(tsm_context, *args, **kwargs)
-
-    return nitsm_code_module
+            try:
+                tsm_context = SemiconductorModuleContext(tsm_context)
+            except Exception:
+                class_name = tsm_context.__class__.__name__
+                raise ValueError(
+                    f"Failed to convert Semiconductor Module context from class '{class_name}'."
+                )
+            args = *args[:index], tsm_context, *args[index + 1 :]  # noqa E203
+        return self._callable(*args, **kwargs)

--- a/systemtests/sessionutils.py
+++ b/systemtests/sessionutils.py
@@ -11,5 +11,5 @@ def get_resource_name_from_session(session) -> str:
 
 
 def get_task_name_from_task(task) -> str:
-    """ Uses a regular expression on the task's repr to return the task's name. """
+    """Uses a regular expression on the task's repr to return the task's name."""
     return re.search(r"Task\(name=(\w*)\)", repr(task)).group(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,13 @@ def _published_data_reader_factory(request):
 
 
 @pytest.fixture
-def standalone_tsm_context(_published_data_reader_factory):
-    return nitsm.codemoduleapi.SemiconductorModuleContext(_published_data_reader_factory[0])
+def standalone_tsm_context_com_object(_published_data_reader_factory):
+    return _published_data_reader_factory[0]
+
+
+@pytest.fixture
+def standalone_tsm_context(standalone_tsm_context_com_object):
+    return nitsm.codemoduleapi.SemiconductorModuleContext(standalone_tsm_context_com_object)
 
 
 class PublishedData:

--- a/tests/empty.pinmap
+++ b/tests/empty.pinmap
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PinMap schemaVersion="1.4" xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<Instruments></Instruments>
+	<Pins></Pins>
+	<PinGroups></PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+	</Sites>
+	<Connections></Connections>
+</PinMap>

--- a/tests/test_codemoduleapi.py
+++ b/tests/test_codemoduleapi.py
@@ -1,0 +1,71 @@
+import pytest
+from nitsm.codemoduleapi import code_module, SemiconductorModuleContext
+
+
+@pytest.mark.pin_map("empty.pinmap")
+class TestCodeModuleApi:
+    """
+    Pytest passes fixtures as keyword arguments while the code_module decorator expects the TSM
+    context to be passed as a positional argument. Therefore, we must redirect the keyword argument
+    to a positional argument by creating surrogate methods.
+    """
+
+    @staticmethod
+    @code_module
+    def _static_method(tsm_context):
+        assert isinstance(tsm_context, SemiconductorModuleContext)
+
+    def test_static_method(self, standalone_tsm_context_com_object):
+        return TestCodeModuleApi._static_method(standalone_tsm_context_com_object)
+
+    @code_module
+    def _instance_method(self, tsm_context):
+        assert isinstance(tsm_context, SemiconductorModuleContext)
+
+    def test_instance_method(self, standalone_tsm_context_com_object):
+        return self._instance_method(standalone_tsm_context_com_object)
+
+    @classmethod
+    @code_module
+    def _class_method(cls, tsm_context):
+        assert issubclass(cls, TestCodeModuleApi)
+        assert isinstance(tsm_context, SemiconductorModuleContext)
+
+    def test_class_method(cls, standalone_tsm_context_com_object):
+        return TestCodeModuleApi._class_method(standalone_tsm_context_com_object)
+
+    @code_module
+    def _invalid_number_of_positional_arguments(self):
+        """Does not contain a positional argument for the TSM context."""
+        assert False  # should not reach this point
+
+    def test_invalid_number_of_positional_arguments(self, standalone_tsm_context_com_object):
+        with pytest.raises(TypeError) as e:
+            self._invalid_number_of_positional_arguments()
+        assert e.value.args[0] == "Invalid number of positional arguments."
+        assert e.value.args[1] == self._invalid_number_of_positional_arguments._callable
+
+    @code_module
+    def _tsm_context_not_first_positional_argument(self, something_else, tsm_context):
+        assert False  # should not reach this point
+
+    @pytest.mark.parametrize("first_argument", (None, int(), str()))
+    def test_tsm_context_not_first_positional_argument(
+        self, first_argument, standalone_tsm_context_com_object
+    ):
+        with pytest.raises(Exception) as e:
+            self._tsm_context_not_first_positional_argument(
+                first_argument, standalone_tsm_context_com_object
+            )
+        assert e.value.args[0].startswith(
+            "Failed to convert Semiconductor Module context from class"
+        )
+
+
+@pytest.mark.pin_map("empty.pinmap")
+def test_function(standalone_tsm_context_com_object):
+    @code_module
+    def func(tsm_context):
+        assert isinstance(tsm_context, SemiconductorModuleContext)
+
+    return func(standalone_tsm_context_com_object)

--- a/tests/test_codemoduleapi.py
+++ b/tests/test_codemoduleapi.py
@@ -31,7 +31,7 @@ class TestCodeModuleApi:
         assert issubclass(cls, TestCodeModuleApi)
         assert isinstance(tsm_context, SemiconductorModuleContext)
 
-    def test_class_method(cls, standalone_tsm_context_com_object):
+    def test_class_method(self, standalone_tsm_context_com_object):
         return TestCodeModuleApi._class_method(standalone_tsm_context_com_object)
 
     @code_module
@@ -45,6 +45,7 @@ class TestCodeModuleApi:
         assert e.value.args[0] == "Invalid number of positional arguments."
         assert e.value.args[1] == self._invalid_number_of_positional_arguments._callable
 
+    # noinspection PyUnusedLocal
     @code_module
     def _tsm_context_not_first_positional_argument(self, something_else, tsm_context):
         assert False  # should not reach this point
@@ -60,6 +61,14 @@ class TestCodeModuleApi:
         assert e.value.args[0].startswith(
             "Failed to convert Semiconductor Module context from class"
         )
+
+    # noinspection PyUnusedLocal
+    @code_module
+    def _positional_arguments_after_tsm_context(self, tsm_context, *args):
+        assert isinstance(tsm_context, SemiconductorModuleContext)
+
+    def test_positional_arguments_after_tsm_context(self, standalone_tsm_context_com_object):
+        self._positional_arguments_after_tsm_context(standalone_tsm_context_com_object, None)
 
 
 @pytest.mark.pin_map("empty.pinmap")

--- a/tests/test_codemoduleapi.py
+++ b/tests/test_codemoduleapi.py
@@ -44,9 +44,9 @@ class TestCodeModuleApi:
         with pytest.raises(TypeError) as e:
             self._invalid_number_of_positional_arguments()
         assert e.value.args[0] == (
-            "The number of arguments to the code module is less expected. It must accept "
-            "as it's first argument the Semiconductor Module context passed from TestStand "
-            "or another code module.",
+            "The number of arguments to the code module is less than expected. It must "
+            "accept as it's first argument the Semiconductor Module context passed from "
+            "TestStand or another code module.",
         )
 
     # noinspection PyUnusedLocal

--- a/tests/test_codemoduleapi.py
+++ b/tests/test_codemoduleapi.py
@@ -1,53 +1,57 @@
+import re
 import pytest
 from nitsm.codemoduleapi import code_module, SemiconductorModuleContext
 
 
 @pytest.mark.pin_map("empty.pinmap")
 class TestCodeModuleApi:
-    """
-    Pytest passes fixtures as keyword arguments while the code_module decorator expects the TSM
-    context to be passed as a positional argument. Therefore, we must redirect the keyword argument
-    to a positional argument by creating surrogate methods.
-    """
+    @staticmethod
+    @code_module
+    def test_static_method_converts(standalone_tsm_context_com_object):
+        assert isinstance(standalone_tsm_context_com_object, SemiconductorModuleContext)
 
     @staticmethod
     @code_module
-    def _static_method(tsm_context):
-        assert isinstance(tsm_context, SemiconductorModuleContext)
-
-    def test_static_method(self, standalone_tsm_context_com_object):
-        return TestCodeModuleApi._static_method(standalone_tsm_context_com_object)
+    def test_static_method_does_not_convert(standalone_tsm_context):
+        assert isinstance(standalone_tsm_context, SemiconductorModuleContext)
 
     @code_module
-    def _instance_method(self, tsm_context):
-        assert isinstance(tsm_context, SemiconductorModuleContext)
+    def test_instance_method_converts(self, standalone_tsm_context_com_object):
+        assert isinstance(standalone_tsm_context_com_object, SemiconductorModuleContext)
 
-    def test_instance_method(self, standalone_tsm_context_com_object):
-        return self._instance_method(standalone_tsm_context_com_object)
+    @code_module
+    def test_instance_method_does_not_convert(self, standalone_tsm_context):
+        assert isinstance(standalone_tsm_context, SemiconductorModuleContext)
 
     @classmethod
     @code_module
-    def _class_method(cls, tsm_context):
+    def test_class_method_converts(cls, standalone_tsm_context_com_object):
         assert issubclass(cls, TestCodeModuleApi)
-        assert isinstance(tsm_context, SemiconductorModuleContext)
+        assert isinstance(standalone_tsm_context_com_object, SemiconductorModuleContext)
 
-    def test_class_method(self, standalone_tsm_context_com_object):
-        return TestCodeModuleApi._class_method(standalone_tsm_context_com_object)
+    @classmethod
+    @code_module
+    def test_class_method_does_not_convert(cls, standalone_tsm_context):
+        assert issubclass(cls, TestCodeModuleApi)
+        assert isinstance(standalone_tsm_context, SemiconductorModuleContext)
 
     @code_module
     def _invalid_number_of_positional_arguments(self):
         """Does not contain a positional argument for the TSM context."""
         assert False  # should not reach this point
 
-    def test_invalid_number_of_positional_arguments(self, standalone_tsm_context_com_object):
+    def test_invalid_number_of_positional_arguments(self):
         with pytest.raises(TypeError) as e:
             self._invalid_number_of_positional_arguments()
-        assert e.value.args[0] == "Invalid number of positional arguments."
-        assert e.value.args[1] == self._invalid_number_of_positional_arguments._callable
+        assert e.value.args[0] == (
+            "The number of arguments to the code module is less expected. It must accept "
+            "as it's first argument the Semiconductor Module context passed from TestStand "
+            "or another code module.",
+        )
 
     # noinspection PyUnusedLocal
     @code_module
-    def _tsm_context_not_first_positional_argument(self, something_else, tsm_context):
+    def _tsm_context_not_first_positional_argument(self, first_argument, tsm_context):
         assert False  # should not reach this point
 
     @pytest.mark.parametrize("first_argument", (None, int(), str()))
@@ -58,23 +62,26 @@ class TestCodeModuleApi:
             self._tsm_context_not_first_positional_argument(
                 first_argument, standalone_tsm_context_com_object
             )
-        assert e.value.args[0].startswith(
-            "Failed to convert Semiconductor Module context from class"
+        assert re.match(
+            r"Failed to convert Semiconductor Module context from class '.*'\.",
+            e.value.args[0],
         )
 
-    # noinspection PyUnusedLocal
+    @pytest.mark.parametrize("second_argument", (None,))
     @code_module
-    def _positional_arguments_after_tsm_context(self, tsm_context, *args):
-        assert isinstance(tsm_context, SemiconductorModuleContext)
-
-    def test_positional_arguments_after_tsm_context(self, standalone_tsm_context_com_object):
-        self._positional_arguments_after_tsm_context(standalone_tsm_context_com_object, None)
+    def test_positional_arguments_after_tsm_context(
+        self, standalone_tsm_context_com_object, second_argument
+    ):
+        assert isinstance(standalone_tsm_context_com_object, SemiconductorModuleContext)
 
 
 @pytest.mark.pin_map("empty.pinmap")
-def test_function(standalone_tsm_context_com_object):
-    @code_module
-    def func(tsm_context):
-        assert isinstance(tsm_context, SemiconductorModuleContext)
+@code_module
+def test_function_converts(standalone_tsm_context_com_object):
+    assert isinstance(standalone_tsm_context_com_object, SemiconductorModuleContext)
 
-    return func(standalone_tsm_context_com_object)
+
+@pytest.mark.pin_map("empty.pinmap")
+@code_module
+def test_function_does_not_convert(standalone_tsm_context):
+    assert isinstance(standalone_tsm_context, SemiconductorModuleContext)


### PR DESCRIPTION
Prior to this change, `@code_module` can only be used on functions. This change will allow `@code_module` to be used on methods defined in classes.