### PR TITLE
Pass tests for independent channels nidcpower sessions

### DIFF
--- a/systemtests/nidcpower_codemodules.py
+++ b/systemtests/nidcpower_codemodules.py
@@ -17,7 +17,9 @@ def open_sessions_channel_expansion(tsm_context: SemiconductorModuleContext):
 def open_sessions(tsm_context: SemiconductorModuleContext):
     instrument_names, channel_strings = tsm_context.get_all_nidcpower_instrument_names()
     for instrument_name, channel_string in zip(instrument_names, channel_strings):
-        session = nidcpower.Session(instrument_name, channel_string, options=OPTIONS)
+        session = nidcpower.Session(
+            instrument_name, channel_string, options=OPTIONS, independent_channels=False
+        )
         tsm_context.set_nidcpower_session_with_channel_string(
             instrument_name, channel_string, session
         )

--- a/systemtests/sessionutils.py
+++ b/systemtests/sessionutils.py
@@ -11,5 +11,5 @@ def get_resource_name_from_session(session) -> str:
 
 
 def get_task_name_from_task(task) -> str:
-    """ Uses a regular expression on the task's repr to return the task's name. """
+    """Uses a regular expression on the task's repr to return the task's name."""
     return re.search(r"Task\(name=(\w*)\)", repr(task)).group(1)


### PR DESCRIPTION
With the addition of independent channels support in nidcpower, we need to update our existing nidcpower system test code modules to use legacy sessions. 