### PR TITLE
Update documentation for set_site_data and set_global_data to explain data type limitation

### DIFF
--- a/src/nitsm/tsmcontext.py
+++ b/src/nitsm/tsmcontext.py
@@ -216,7 +216,6 @@ class SemiconductorModuleContext:
                 contains data for each site in the Semiconductor Module context, each item in the
                 sequence contains data for the site specified by the corresponding item in the
                 site_numbers property.
-
         """
 
         return self._context.SetSiteData(data_id, data)

--- a/src/nitsm/tsmcontext.py
+++ b/src/nitsm/tsmcontext.py
@@ -203,9 +203,10 @@ class SemiconductorModuleContext:
         """
         Associates a data item with each site. You can associate data with all sites or with the
         sub-set of sites in the Semiconductor Module context. You can use this method to store
-        instrument sessions or other per-site data you initialize in a central location but access
-        within each site. The data item is accessible from a process model controller execution and
-        the site with which the data is associated.
+        per-site data you initialize in a central location but access within each site. The data
+        item is accessible from a process model controller execution and the site with which the
+        data is associated. This method supports only basic data types and sequences of basic
+        data types that can be represented by a COM VARIANT.
 
         Args:
             data_id: A unique ID to distinguish the data.
@@ -215,6 +216,7 @@ class SemiconductorModuleContext:
                 contains data for each site in the Semiconductor Module context, each item in the
                 sequence contains data for the site specified by the corresponding item in the
                 site_numbers property.
+
         """
 
         return self._context.SetSiteData(data_id, data)
@@ -248,10 +250,11 @@ class SemiconductorModuleContext:
 
     def set_global_data(self, data_id: str, data: _Any) -> None:
         """
-        Associates a data item with a data_id. You can use this method to store an instrument
-        session or other data you initialize in a central location but access from multiple sites.
-        The data item is accessible from a process model controller execution and all of its test
-        socket executions.
+        Associates a data item with a data_id. You can use this method to store data you initialize
+        in a central location but access from multiple sites. The data item is accessible from a
+        process model controller execution and all of its test socket executions. This method
+        supports only basic data types and sequences of basic data types that can be represented by
+        a COM VARIANT.
 
         Args:
             data_id: A unique ID to distinguish the data.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes inaccurate information about storing sessions and adds qualification about supported data types to the documentation of the set_site_data and set_global_data methods.

### Why should this Pull Request be merged?

To avoid inaccurate documentation until issue #104 is resolved.

### What testing has been done?

None.

- [ ] I have run the automated tests (required if there are code changes)