### PR TITLE
Ignore pinmapinterfaces in coverage now that it is private

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 source_pkgs = nitsm
 omit =
-    */nitsm/pinmapinterfaces.py
+    */nitsm/_pinmapinterfaces.py
     */nitsm/__init__.py
 
 [paths]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changes the `.coverage` file to ignore `_pinmapinterfaces.py`. 

### Why should this Pull Request be merged?

We shouldn't take coverage metrics on this file.

### What testing has been done?

Tested locally.

- [x] I have run the automated tests (required if there are code changes)