### PR TITLE
Simplify and update lint.yml to display correct job name 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,20 +8,17 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
 
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [3.6]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.6'
 
     - name: Upgrade pip
       run: |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes the python version matrix from the lint workflow since we don't need it.  Also updates the job name from `build` to `lint`.

### Why should this Pull Request be merged?

Improves workflow cleanliness.

### What testing has been done?

Manual testing with GitHub

- [ ] I have run the automated tests (required if there are code changes)