### PR TITLE
Fix tox build and test pipelines

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ source_pkgs = nitsm
 omit =
     */nitsm/_pinmapinterfaces.py
     */nitsm/__init__.py
-    */nitsm/debug.py  # requires manual testing
+    */nitsm/debug.py
 
 [paths]
 tox =

--- a/.github/workflows/test-build-install.yml
+++ b/.github/workflows/test-build-install.yml
@@ -1,4 +1,4 @@
-name: Test Build Package
+name: Test Build and Install Package
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -20,3 +20,6 @@ jobs:
 
     - name: Build package
       uses: ./.github/actions/build
+
+    - name: Install package
+      run: pip install nitsm --no-index -f dist/

--- a/.github/workflows/test-build-install.yml
+++ b/.github/workflows/test-build-install.yml
@@ -22,4 +22,6 @@ jobs:
       uses: ./.github/actions/build
 
     - name: Install package
-      run: pip install nitsm --no-index -f dist/
+      run: |
+        pip install pywin32
+        pip install nitsm --no-index -f dist/

--- a/.github/workflows/test-build-install.yml
+++ b/.github/workflows/test-build-install.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  build-install:
 
     runs-on: windows-latest
 
@@ -23,5 +23,5 @@ jobs:
 
     - name: Install package
       run: |
-        pip install pywin32
-        pip install nitsm --no-index -f dist/
+        pip install pywin32  # install from pypi
+        pip install nitsm --no-index -f dist/  # install local distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ markers = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
+isolated_build = True
 envlist = clean, py3{6,7,8}-tests, py3{6,7,8}-systemtests, report
 
 [testenv]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,7 @@ long_description_content_type = text/markdown
 
 [options]
 install_requires =
-    pywin32>=228
-    platform_system=='Windows'
+    pywin32>=228;platform_system=='Windows'
 python_requires = >=3.6
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ long_description_content_type = text/markdown
 [options]
 install_requires =
     pywin32>=228
-    platform_system=="Windows"
+    platform_system=='Windows'
 python_requires = >=3.6
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description_content_type = text/markdown
 
 [options]
 install_requires =
-    pywin32>=228;platform_system=='Windows'
+    pywin32>=228;platform_system=="Windows"
 python_requires = >=3.6
 package_dir =
     =src


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Tox needs the flag `isolated_build = True` to use a PEP 517 compliant build system.  Tox fails to create the environments unless this flag is set.
- pip was not installing `pywin32` alongsite `nitsm`. Discovered we need to place `pywin32` and `platform_requires` on the same line in `install_requires`.
- coverage was still including `debug.py` because `.coveragerc` only supports comments if the line starts with `#`

### Why should this Pull Request be merged?

Fixes issues with the test pipeline and built package.

### What testing has been done?

Unit tests run locally.

- [x] I have run the automated tests (required if there are code changes)