### PR TITLE
Update pipeline to run tests twice, with different versions of TSM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,27 @@ jobs:
       py -3 -m pip install --upgrade tox
     displayName: 'Install or upgrade tox'
 
+  - task: PowerShell@2
+    displayName: 'Switch to old TestStand/TSM'
+    inputs:
+      targetType: filePath
+      filePath: 'C:\ProgramData\Salt Project\salt\srv\salt\tsm\Activate_TSVersion.ps1'
+      arguments: '-VersionToActivate old'
+
   - script: |
-      tox
-    displayName: 'Run python unit tests'
+      tox -- older
+    displayName: 'Run python unit tests with older version of TestStand/TSM'
+
+  - task: PowerShell@2
+    displayName: 'Switch to new TestStand/TSM'
+    inputs:
+      targetType: filePath
+      filePath: 'C:\ProgramData\Salt Project\salt\srv\salt\tsm\Activate_TSVersion.ps1'
+      arguments: '-VersionToActivate new'
+
+  - script: |
+      tox -- newer
+    displayName: 'Run python unit tests with newer version of TestStand/TSM'
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'Switch to old TestStand/TSM'
     inputs:
       targetType: filePath
-      filePath: 'C:\ProgramData\Salt Project\salt\srv\salt\tsm\Activate_TSVersion.ps1'
+      filePath: 'C:\Activate_TSVersion.ps1'
       arguments: '-VersionToActivate old'
 
   - script: |
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Switch to new TestStand/TSM'
     inputs:
       targetType: filePath
-      filePath: 'C:\ProgramData\Salt Project\salt\srv\salt\tsm\Activate_TSVersion.ps1'
+      filePath: 'C:\Activate_TSVersion.ps1'
       arguments: '-VersionToActivate new'
 
   - script: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,12 @@ deps =
     nidaqmx
     nifgen
 commands =
-    tests: pytest tests --junitxml={envname}-results.xml --cov --cov-report=term
-    systemtests: pytest systemtests --junitxml={envname}-results.xml --cov --cov-report=term
+    tests: pytest tests --junitxml={envname}-{posargs}-tsm-version-results.xml --cov --cov-report=term
+    systemtests: pytest systemtests --junitxml={envname}-{posargs}-tsm-version-results.xml --cov --cov-report=term
 passenv =
     systemtests: TestStandPublic64 ProgramFiles(x86)
 setenv =
-    tests,systemtests: COVERAGE_FILE = .coverage.{envname}
+    tests,systemtests: COVERAGE_FILE = .coverage.{envname}-{posargs}-tsm-version
 
 [testenv:clean]
 deps = coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,12 @@ deps =
     nidaqmx
     nifgen
 commands =
-    tests: pytest tests --junitxml={envname}-{posargs}-tsm-version-results.xml --cov --cov-report=term
-    systemtests: pytest systemtests --junitxml={envname}-{posargs}-tsm-version-results.xml --cov --cov-report=term
+    tests: pytest tests --junitxml={envname}-{posargs:any}-tsm-version-results.xml --cov --cov-report=term
+    systemtests: pytest systemtests --junitxml={envname}-{posargs:any}-tsm-version-results.xml --cov --cov-report=term
 passenv =
     systemtests: TestStandPublic64 ProgramFiles(x86)
 setenv =
-    tests,systemtests: COVERAGE_FILE = .coverage.{envname}-{posargs}-tsm-version
+    tests,systemtests: COVERAGE_FILE = .coverage.{envname}-{posargs:any}-tsm-version
 
 [testenv:clean]
 deps = coverage

--- a/systemtests/conftest.py
+++ b/systemtests/conftest.py
@@ -12,18 +12,23 @@ try:
 except KeyError:
     _python_environment_path = ""  # global interpreter
 
+
 def get_env_variable_from_registry(variable_name):
-    key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment")
+    key = winreg.CreateKey(
+        winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment"
+    )
     return winreg.QueryValueEx(key, variable_name)[0]
 
+
 _teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
+
 
 class SystemTestRunner:
     # subprocess.run with check=True will throw an exception if the return code is non-zero
     # with stdout set to subprocess.PIPE, exit code and stdout will be included in the exception
     _SUBPROCESS_RUN_OPTIONS = {"stdout": subprocess.PIPE, "timeout": 180, "check": True}
 
-    # we need to get the TestStand variables from the registry since the pipeline process 
+    # we need to get the TestStand variables from the registry since the pipeline process
     # does not refresh its environment after running the TestStand version selector
 
     _csharp_oi_path = os.path.join(
@@ -84,6 +89,7 @@ class SystemTestRunner:
             **self._SUBPROCESS_RUN_OPTIONS,
         )
         return True
+
 
 @pytest.fixture(scope="session", autouse=True)
 def teststand_login_override():

--- a/systemtests/conftest.py
+++ b/systemtests/conftest.py
@@ -17,6 +17,7 @@ def get_env_variable_from_registry(variable_name):
     return winreg.QueryValueEx(key, variable_name)[0]
 
 _teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
+
 class SystemTestRunner:
     # subprocess.run with check=True will throw an exception if the return code is non-zero
     # with stdout set to subprocess.PIPE, exit code and stdout will be included in the exception

--- a/systemtests/conftest.py
+++ b/systemtests/conftest.py
@@ -12,19 +12,18 @@ try:
 except KeyError:
     _python_environment_path = ""  # global interpreter
 
+def get_env_variable_from_registry(variable_name):
+    key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment")
+    return winreg.QueryValueEx(key, variable_name)[0]
 
+_teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
 class SystemTestRunner:
     # subprocess.run with check=True will throw an exception if the return code is non-zero
     # with stdout set to subprocess.PIPE, exit code and stdout will be included in the exception
     _SUBPROCESS_RUN_OPTIONS = {"stdout": subprocess.PIPE, "timeout": 180, "check": True}
 
-    def get_env_variable_from_registry(variable_name):
-        key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment")
-        return winreg.QueryValueEx(key, variable_name)[0]
-
     # we need to get the TestStand variables from the registry since the pipeline process 
     # does not refresh its environment after running the TestStand version selector
-    _teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
 
     _csharp_oi_path = os.path.join(
         _teststand_public_path,

--- a/tools/makepy_pinmapinterfaces.py
+++ b/tools/makepy_pinmapinterfaces.py
@@ -3,13 +3,21 @@ import os.path
 import winreg
 from win32com.client import makepy
 
+
 def get_env_variable_from_registry(variable_name):
-    key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment")
+    key = winreg.CreateKey(
+        winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment"
+    )
     return winreg.QueryValueEx(key, variable_name)[0]
+
 
 output_file = os.path.join(os.path.dirname(__file__), "_pinmapinterfaces.py")
 _teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
-pmi_type_library = os.path.join(_teststand_public_path,  "Bin", "NationalInstruments.TestStand.SemiconductorModule.PinMapInterfaces.tlb")
+pmi_type_library = os.path.join(
+    _teststand_public_path,
+    "Bin",
+    "NationalInstruments.TestStand.SemiconductorModule.PinMapInterfaces.tlb",
+)
 
 sys.argv = ["makepy", "-o", output_file, pmi_type_library]
 

--- a/tools/makepy_pinmapinterfaces.py
+++ b/tools/makepy_pinmapinterfaces.py
@@ -4,17 +4,10 @@ import winreg
 from win32com.client import makepy
 
 
-def get_env_variable_from_registry(variable_name):
-    key = winreg.CreateKey(
-        winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment"
-    )
-    return winreg.QueryValueEx(key, variable_name)[0]
-
-
 output_file = os.path.join(os.path.dirname(__file__), "_pinmapinterfaces.py")
-_teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
+teststand_public_path = os.environ["TestStandPublic64"]
 pmi_type_library = os.path.join(
-    _teststand_public_path,
+    teststand_public_path,
     "Bin",
     "NationalInstruments.TestStand.SemiconductorModule.PinMapInterfaces.tlb",
 )

--- a/tools/makepy_pinmapinterfaces.py
+++ b/tools/makepy_pinmapinterfaces.py
@@ -1,12 +1,15 @@
 import sys
 import os.path
+import winreg
 from win32com.client import makepy
 
+def get_env_variable_from_registry(variable_name):
+    key = winreg.CreateKey(winreg.HKEY_LOCAL_MACHINE, r"System\CurrentControlSet\Control\Session Manager\Environment")
+    return winreg.QueryValueEx(key, variable_name)[0]
+
 output_file = os.path.join(os.path.dirname(__file__), "_pinmapinterfaces.py")
-pmi_type_library = (
-    r"C:\Program Files\National Instruments\TestStand 2020\Bin"
-    r"\NationalInstruments.TestStand.SemiconductorModule.PinMapInterfaces.tlb"
-)
+_teststand_public_path = get_env_variable_from_registry("TestStandPublic64")
+pmi_type_library = os.path.join(_teststand_public_path,  "Bin", "NationalInstruments.TestStand.SemiconductorModule.PinMapInterfaces.tlb")
 
 sys.argv = ["makepy", "-o", output_file, pmi_type_library]
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update [test running pipeline](https://ni.visualstudio.com/DevCentral/_build?definitionId=5945&_a=summary) to run the automated tests twice: once with the latest released version of TSM and once with the next-to-latest released version of TSM. Each test run produces a different set of results files. Both sets are published in the [PublishTestResults@2 task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=trx%2Cyaml) of the pipeline.

### Why should this Pull Request be merged?

Increases reliability of the automated tests

### What testing has been done?

1. Ensured that the testing VM configuration was correctly updated (those changes belong to the ni-central repo and so are not included in this PR).
2. Ensured that the changes made to the pipeline work as expected with a stubbed version of the Activate_TSVersion.ps1 script (the reason we use a stub is because the VM configuration changes aren't yet final, and so the VM isn't yet setup correctly. For this same reason, we will not complete this PR until those changes are final and the VM has been updated by the deployment pipeline, otherwise the automated tests pipeline would fail. These two PRs are mutually interdependent).
3. Tested that the changes made to pyproject.toml have the desired effect by [invoking tox with a command line argument](https://tox.wiki/en/latest/example/general.html#interactively-passing-positional-arguments) in the current VM.

- [X] I have run the automated tests (required if there are code changes)