### PR TITLE
Updated python for lint to 3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.10'
 
     - name: Upgrade pip
       run: |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

python 3.6 is not available.

### What does this Pull Request accomplish?

Allows lint to run

### Why should this Pull Request be merged?



### What testing has been done?

None

- [ ] I have run the automated tests (required if there are code changes)