### PR TITLE
Python 3.11 support added

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
     displayName: 'Upgrade pip'
 
   - script: |
-      python -m pip install --upgrade tox
+      python -m pip install --upgrade "tox<4" "virtualenv<20.22"
     displayName: 'Install or upgrade tox'
 
   - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
       arguments: '-VersionToActivate old'
 
   - script: |
-      tox -- older
+      python -m tox -- older
     displayName: 'Run python unit tests with older version of TestStand/TSM'
 
   - task: PowerShell@2
@@ -43,7 +43,7 @@ jobs:
       arguments: '-VersionToActivate new'
 
   - script: |
-      tox -- newer
+      python -m tox -- newer
     displayName: 'Run python unit tests with newer version of TestStand/TSM'
 
   - task: PublishTestResults@2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target-version = ["py36", "py37", "py38"]
+target-version = ["py36", "py37", "py38", "py311"]
 extend-exclude = "^/src/nitsm/_pinmapinterfaces.py"
 
 [tool.ni-python-styleguide]
@@ -23,7 +23,7 @@ markers = [
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = clean, py3{6,7,8}-tests, py3{6,7,8}-systemtests, report
+envlist = clean, py3{6,7,8,11}-tests, py3{6,7,8,11}-systemtests, report
 
 [testenv]
 deps =

--- a/src/nitsm/tsmcontext.py
+++ b/src/nitsm/tsmcontext.py
@@ -1,4 +1,5 @@
 """TSM Context Wrapper"""
+
 import ctypes.wintypes
 import time
 import typing

--- a/systemtests/nidigital_codemodules.py
+++ b/systemtests/nidigital_codemodules.py
@@ -37,9 +37,9 @@ def measure_ppmu(
     for session, pin_set_string in zip(sessions, pin_set_strings):
         # call some methods on the session to ensure no errors
         session.pins[pin_set_string].ppmu_aperture_time = 4e-6
-        session.pins[
-            pin_set_string
-        ].ppmu_aperture_time_units = nidigital.PPMUApertureTimeUnits.SECONDS
+        session.pins[pin_set_string].ppmu_aperture_time_units = (
+            nidigital.PPMUApertureTimeUnits.SECONDS
+        )
         session.pins[pin_set_string].ppmu_output_function = nidigital.PPMUOutputFunction.CURRENT
         session.pins[pin_set_string].ppmu_current_level_range = 2e-6
         session.pins[pin_set_string].ppmu_current_level = 2e-6

--- a/tests/test_custom_instruments.py
+++ b/tests/test_custom_instruments.py
@@ -5,7 +5,7 @@ from nitsm.pinquerycontexts import PinQueryContext
 
 @pytest.fixture
 def simulated_custom_instrument_sessions(standalone_tsm_context):
-    (instrument_names, channel_group_ids, _) = standalone_tsm_context.get_custom_instrument_names(
+    instrument_names, channel_group_ids, _ = standalone_tsm_context.get_custom_instrument_names(
         TestCustomInstruments.pin_map_instrument_type_id
     )
     sessions = tuple(range(len(instrument_names)))


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds Python 3.11 to the tox test matrix (both unit tests and system tests)
- Switches `tox` to `python -m tox` in azure-pipelines.yml since the CI machine uses pyenv-win which doesn't have `tox` on PATH directly
- Applies black formatting fixes to 3 files

### Why should this Pull Request be merged?

The CI pipeline fails because `tox` isn't recognized as a command on the build agent (pyenv-win doesn't add scripts to PATH). Using `python -m tox` resolves this. Additionally, Python 3.11 is installed on the build agent and should be included in the test matrix to ensure compatibility.

### What testing has been done?

- [x] I have run the automated tests (required if there are code changes)
- Verified Python 3.11.9 is installed on the CI agent via `pyenv versions`
- Ran `python -m black --check .` locally to confirm formatting is clean
- Pipeline run on this branch to validate the tox and python version changes