### PR TITLE
Update workflows to latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: '3.11'
 
     - name: Build package
       uses: ./.github/actions/build
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: '3.11'
 
     - name: Build package
       uses: ./.github/actions/build
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/test-build-install.yml
+++ b/.github/workflows/test-build-install.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: '3.11'
 
     - name: Build package
       uses: ./.github/actions/build


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates all GitHub Actions workflows to use modern action versions and Python 3.11 for builds:

- `actions/checkout@v2` → `@v4` (v2 uses a deprecated Node.js runtime)
- `actions/setup-python@v2` → `@v5` (v2 cannot reliably install Python 3.11+)
- `python-version: 3.6` → `3.11` in publish-pypi, publish-testpypi, and test-build-install workflows
- `pypa/gh-action-pypi-publish` updated from a pinned 2021 commit hash to `release/v1`
- lint.yml action versions updated (Python version unchanged at 3.10)

### Why should this Pull Request be merged?

- Python 3.6 reached end-of-life in December 2021 and is no longer available in `actions/setup-python@v5`, which will cause workflow failures.
- `actions/checkout@v2` and `actions/setup-python@v2` use a deprecated Node.js runtime and will stop working on newer GitHub runners.
- The pinned `pypa/gh-action-pypi-publish` commit is ~5 years old and missing security fixes.
- The build produces a pure Python wheel (`py3-none-any`), so building with 3.11 is fully backwards compatible — the wheel installs on any Python >=3.6 as declared in `setup.cfg`.

### What testing has been done?

- [ ] I have run the automated tests (required if there are code changes)

No code changes — only CI workflow files were modified. Recommend triggering the TestPyPI publish workflow (`workflow_dispatch`) after merge to verify end-to-end.