### PR TITLE
Use trusted publishers for PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,19 +7,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: "3.x"
 
     - name: Build package
       uses: ./.github/actions/build
 
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -7,13 +7,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: "3.x"
 
     - name: Build package
       uses: ./.github/actions/build
@@ -21,6 +24,4 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/

--- a/src/nitsm/__init__.py
+++ b/src/nitsm/__init__.py
@@ -1,3 +1,3 @@
 """NI TestStand Semiconductor Module Python API"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitsm-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the Publish to PyPi and Publish to PyPI Test actions to use the new Trusted Publishers workflow from PyPi.

### Why should this Pull Request be merged?

The current actions are tied to a maintainer's credentials. To decouple publishing package updates to a specific maintainer's credentials, we can have NI as a trusted publisher for the package. 

### What testing has been done?

Test the action's workflows.

- [x] I have run the automated tests (required if there are code changes)